### PR TITLE
Proposal for renaming CacheId stuff

### DIFF
--- a/.g8/intPage/app/controllers/$className$Controller.scala
+++ b/.g8/intPage/app/controllers/$className$Controller.scala
@@ -21,7 +21,7 @@ class $className$Controller @Inject()(
                                         override val messagesApi: MessagesApi,
                                         dataCacheConnector: DataCacheConnector,
                                         navigator: Navigator,
-                                        identify: CacheIdentifierAction,
+                                        identify: IdentifierAction,
                                         getData: DataRetrievalAction,
                                         requireData: DataRequiredAction,
                                         formProvider: $className$FormProvider) extends FrontendController with I18nSupport {

--- a/.g8/optionsPage/app/controllers/$className$Controller.scala
+++ b/.g8/optionsPage/app/controllers/$className$Controller.scala
@@ -22,7 +22,7 @@ class $className$Controller @Inject()(
                                         override val messagesApi: MessagesApi,
                                         dataCacheConnector: DataCacheConnector,
                                         navigator: Navigator,
-                                        identify: CacheIdentifierAction,
+                                        identify: IdentifierAction,
                                         getData: DataRetrievalAction,
                                         requireData: DataRequiredAction,
                                         formProvider: $className$FormProvider) extends FrontendController with I18nSupport with Enumerable.Implicits {

--- a/.g8/questionPage/app/controllers/$className$Controller.scala
+++ b/.g8/questionPage/app/controllers/$className$Controller.scala
@@ -20,7 +20,7 @@ class $className$Controller @Inject()(appConfig: FrontendAppConfig,
                                                   override val messagesApi: MessagesApi,
                                                   dataCacheConnector: DataCacheConnector,
                                                   navigator: Navigator,
-                                                  identify: CacheIdentifierAction,
+                                                  identify: IdentifierAction,
                                                   getData: DataRetrievalAction,
                                                   requireData: DataRequiredAction,
                                                   formProvider: $className$FormProvider) extends FrontendController with I18nSupport {

--- a/.g8/stringPage/app/controllers/$className$Controller.scala
+++ b/.g8/stringPage/app/controllers/$className$Controller.scala
@@ -21,7 +21,7 @@ class $className$Controller @Inject()(
                                         override val messagesApi: MessagesApi,
                                         dataCacheConnector: DataCacheConnector,
                                         navigator: Navigator,
-                                        identify: CacheIdentifierAction,
+                                        identify: IdentifierAction,
                                         getData: DataRetrievalAction,
                                         requireData: DataRequiredAction,
                                         formProvider: $className$FormProvider) extends FrontendController with I18nSupport {

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -29,7 +29,7 @@ class Module extends AbstractModule {
     bind(classOf[DataRequiredAction]).to(classOf[DataRequiredActionImpl]).asEagerSingleton()
 
     // For session based storage instead of cred based, change to SessionActionImpl
-    bind(classOf[CacheIdentifierAction]).to(classOf[SessionActionImpl]).asEagerSingleton()
+    bind(classOf[IdentifierAction]).to(classOf[SessionIdentifierAction]).asEagerSingleton()
 
     // Controllers
     bind(classOf[EligibleController]).to(classOf[EligibleControllerImpl]).asEagerSingleton()

--- a/app/controllers/BeforeYouStartController.scala
+++ b/app/controllers/BeforeYouStartController.scala
@@ -29,7 +29,7 @@ import scala.concurrent.Future
 
 class BeforeYouStartController @Inject()(appConfig: FrontendAppConfig,
                                          override val messagesApi: MessagesApi,
-                                         identify: CacheIdentifierAction) extends FrontendController with I18nSupport {
+                                         identify: IdentifierAction) extends FrontendController with I18nSupport {
 
   def onPageLoad = (identify) {
     implicit request =>

--- a/app/controllers/CorporateOfficerController.scala
+++ b/app/controllers/CorporateOfficerController.scala
@@ -36,7 +36,7 @@ class CorporateOfficerController @Inject()(appConfig: FrontendAppConfig,
                                          override val messagesApi: MessagesApi,
                                          dataCacheConnector: DataCacheConnector,
                                          navigator: Navigator,
-                                         identify: CacheIdentifierAction,
+                                         identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,
                                          formProvider: CorporateOfficerFormProvider) extends FrontendController with I18nSupport {

--- a/app/controllers/CorporateShareholderController.scala
+++ b/app/controllers/CorporateShareholderController.scala
@@ -36,7 +36,7 @@ class CorporateShareholderController @Inject()(appConfig: FrontendAppConfig,
                                          override val messagesApi: MessagesApi,
                                          dataCacheConnector: DataCacheConnector,
                                          navigator: Navigator,
-                                         identify: CacheIdentifierAction,
+                                         identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,
                                          formProvider: CorporateShareholderFormProvider) extends FrontendController with I18nSupport {

--- a/app/controllers/EligibleController.scala
+++ b/app/controllers/EligibleController.scala
@@ -28,7 +28,7 @@ import views.html.eligible
 
 class EligibleControllerImpl @Inject()(val appConfig: FrontendAppConfig,
                                        override val messagesApi: MessagesApi,
-                                       val identify: CacheIdentifierAction) extends EligibleController {
+                                       val identify: IdentifierAction) extends EligibleController {
   val postSignInUri     = appConfig.postSignInUrl
   val ggMakeAccountUrl  = appConfig.ggMakeAccountUrl
   val companyRegURI     = s"${appConfig.compRegFEURL}${appConfig.compRegFEURI}"
@@ -39,7 +39,7 @@ trait EligibleController extends FrontendController with I18nSupport {
   val companyRegURI : String
   val ggMakeAccountUrl : String
   val postSignInUri : String
-  val identify : CacheIdentifierAction
+  val identify : IdentifierAction
 
   private[controllers] def buildCreateAccountURL: String = {
     val crfePostSignIn = s"$companyRegURI$postSignInUri"

--- a/app/controllers/IneligibleController.scala
+++ b/app/controllers/IneligibleController.scala
@@ -29,7 +29,7 @@ import scala.concurrent.Future
 
 class IneligibleController @Inject()(appConfig: FrontendAppConfig,
                                      override val messagesApi: MessagesApi,
-                                     identify: CacheIdentifierAction) extends FrontendController with I18nSupport {
+                                     identify: IdentifierAction) extends FrontendController with I18nSupport {
 
   def onPageLoad(inelligibleType: String) = (identify) {
     implicit request =>

--- a/app/controllers/OrdinarySharesController.scala
+++ b/app/controllers/OrdinarySharesController.scala
@@ -38,7 +38,7 @@ class OrdinarySharesController @Inject()(
                                         override val messagesApi: MessagesApi,
                                         dataCacheConnector: DataCacheConnector,
                                         navigator: Navigator,
-                                        identify: CacheIdentifierAction,
+                                        identify: IdentifierAction,
                                         getData: DataRetrievalAction,
                                         requireData: DataRequiredAction,
                                         formProvider: OrdinarySharesFormProvider) extends FrontendController with I18nSupport with Enumerable.Implicits {

--- a/app/controllers/ParentCompanyController.scala
+++ b/app/controllers/ParentCompanyController.scala
@@ -36,7 +36,7 @@ class ParentCompanyController @Inject()(appConfig: FrontendAppConfig,
                                          override val messagesApi: MessagesApi,
                                          dataCacheConnector: DataCacheConnector,
                                          navigator: Navigator,
-                                         identify: CacheIdentifierAction,
+                                         identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,
                                          formProvider: ParentCompanyFormProvider) extends FrontendController with I18nSupport {

--- a/app/controllers/SecureRegisterController.scala
+++ b/app/controllers/SecureRegisterController.scala
@@ -36,7 +36,7 @@ class SecureRegisterController @Inject()(appConfig: FrontendAppConfig,
                                          override val messagesApi: MessagesApi,
                                          dataCacheConnector: DataCacheConnector,
                                          navigator: Navigator,
-                                         identify: CacheIdentifierAction,
+                                         identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,
                                          formProvider: SecureRegisterFormProvider) extends FrontendController with I18nSupport {

--- a/app/controllers/TakingOverBusinessController.scala
+++ b/app/controllers/TakingOverBusinessController.scala
@@ -36,7 +36,7 @@ class TakingOverBusinessController @Inject()(appConfig: FrontendAppConfig,
                                          override val messagesApi: MessagesApi,
                                          dataCacheConnector: DataCacheConnector,
                                          navigator: Navigator,
-                                         identify: CacheIdentifierAction,
+                                         identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,
                                          formProvider: TakingOverBusinessFormProvider) extends FrontendController with I18nSupport {

--- a/app/controllers/TooManyDirectorsController.scala
+++ b/app/controllers/TooManyDirectorsController.scala
@@ -36,7 +36,7 @@ class TooManyDirectorsController @Inject()(appConfig: FrontendAppConfig,
                                          override val messagesApi: MessagesApi,
                                          dataCacheConnector: DataCacheConnector,
                                          navigator: Navigator,
-                                         identify: CacheIdentifierAction,
+                                         identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,
                                          formProvider: TooManyDirectorsFormProvider) extends FrontendController with I18nSupport {

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -20,7 +20,7 @@ import com.google.inject.Inject
 import play.api.mvc.ActionTransformer
 import connectors.DataCacheConnector
 import utils.UserAnswers
-import models.requests.{CacheIdentifierRequest, OptionalDataRequest}
+import models.requests.{IdentifierRequest, OptionalDataRequest}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.HeaderCarrierConverter
 
@@ -29,14 +29,14 @@ import scala.concurrent.Future
 
 class DataRetrievalActionImpl @Inject()(val dataCacheConnector: DataCacheConnector) extends DataRetrievalAction {
 
-  override protected def transform[A](request: CacheIdentifierRequest[A]): Future[OptionalDataRequest[A]] = {
+  override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] = {
     implicit val hc = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
-    dataCacheConnector.fetch(request.cacheId).map {
-      case None => OptionalDataRequest(request.request, request.cacheId, None)
-      case Some(data) => OptionalDataRequest(request.request, request.cacheId, Some(new UserAnswers(data)))
+    dataCacheConnector.fetch(request.identifier).map {
+      case None => OptionalDataRequest(request.request, request.identifier, None)
+      case Some(data) => OptionalDataRequest(request.request, request.identifier, Some(new UserAnswers(data)))
     }
   }
 }
 
-trait DataRetrievalAction extends ActionTransformer[CacheIdentifierRequest, OptionalDataRequest]
+trait DataRetrievalAction extends ActionTransformer[IdentifierRequest, OptionalDataRequest]

--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -23,22 +23,22 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.Retrievals
 import config.FrontendAppConfig
 import controllers.routes
-import models.requests.CacheIdentifierRequest
+import models.requests.IdentifierRequest
 import uk.gov.hmrc.http.UnauthorizedException
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AuthActionImpl @Inject()(override val authConnector: AuthConnector, config: FrontendAppConfig)
-                              (implicit ec: ExecutionContext) extends CacheIdentifierAction with AuthorisedFunctions {
+class AuthenticatedIdentifierAction @Inject()(override val authConnector: AuthConnector, config: FrontendAppConfig)
+                                             (implicit ec: ExecutionContext) extends IdentifierAction with AuthorisedFunctions {
 
-  override def invokeBlock[A](request: Request[A], block: (CacheIdentifierRequest[A]) => Future[Result]): Future[Result] = {
+  override def invokeBlock[A](request: Request[A], block: (IdentifierRequest[A]) => Future[Result]): Future[Result] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
     authorised().retrieve(Retrievals.internalId) {
       _.map {
-        internalId => block(CacheIdentifierRequest(request, internalId))
+        internalId => block(IdentifierRequest(request, internalId))
       }.getOrElse(throw new UnauthorizedException("Unable to retrieve internal Id"))
     } recover {
       case ex: NoActiveSession =>
@@ -57,16 +57,16 @@ class AuthActionImpl @Inject()(override val authConnector: AuthConnector, config
   }
 }
 
-trait CacheIdentifierAction extends ActionBuilder[CacheIdentifierRequest] with ActionFunction[Request, CacheIdentifierRequest]
+trait IdentifierAction extends ActionBuilder[IdentifierRequest] with ActionFunction[Request, IdentifierRequest]
 
-class SessionActionImpl @Inject()(config: FrontendAppConfig)
-                                 (implicit ec: ExecutionContext) extends CacheIdentifierAction {
+class SessionIdentifierAction @Inject()(config: FrontendAppConfig)
+                                       (implicit ec: ExecutionContext) extends IdentifierAction {
 
-  override def invokeBlock[A](request: Request[A], block: (CacheIdentifierRequest[A]) => Future[Result]): Future[Result] = {
+  override def invokeBlock[A](request: Request[A], block: (IdentifierRequest[A]) => Future[Result]): Future[Result] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
     hc.sessionId match {
-      case Some(session) => block(CacheIdentifierRequest(request, session.value))
+      case Some(session) => block(IdentifierRequest(request, session.value))
       case None => Future.successful(Redirect(routes.SessionExpiredController.onPageLoad()))
     }
   }

--- a/app/models/requests/IdentifierRequest.scala
+++ b/app/models/requests/IdentifierRequest.scala
@@ -18,4 +18,4 @@ package models.requests
 
 import play.api.mvc.{Request, WrappedRequest}
 
-case class CacheIdentifierRequest[A] (request: Request[A], cacheId: String) extends WrappedRequest[A](request)
+case class IdentifierRequest[A](request: Request[A], identifier: String) extends WrappedRequest[A](request)

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -30,14 +30,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class AuthActionSpec extends SpecBase {
 
-  class Harness(authAction: CacheIdentifierAction) extends Controller {
+  class Harness(authAction: IdentifierAction) extends Controller {
     def onPageLoad() = authAction { request => Ok }
   }
 
   "Auth Action" when {
     "the user hasn't logged in" must {
       "redirect the user to log in " in {
-        val authAction = new AuthActionImpl(new FakeFailingAuthConnector(new MissingBearerToken), frontendAppConfig)
+        val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new MissingBearerToken), frontendAppConfig)
         val controller = new Harness(authAction)
         val result = controller.onPageLoad()(fakeRequest)
         status(result) mustBe SEE_OTHER
@@ -47,7 +47,7 @@ class AuthActionSpec extends SpecBase {
 
     "the user's session has expired" must {
       "redirect the user to log in " in {
-        val authAction = new AuthActionImpl(new FakeFailingAuthConnector(new BearerTokenExpired), frontendAppConfig)
+        val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new BearerTokenExpired), frontendAppConfig)
         val controller = new Harness(authAction)
         val result = controller.onPageLoad()(fakeRequest)
         status(result) mustBe SEE_OTHER
@@ -57,7 +57,7 @@ class AuthActionSpec extends SpecBase {
 
     "the user doesn't have sufficient enrolments" must {
       "redirect the user to the unauthorised page" in {
-        val authAction = new AuthActionImpl(new FakeFailingAuthConnector(new InsufficientEnrolments), frontendAppConfig)
+        val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientEnrolments), frontendAppConfig)
         val controller = new Harness(authAction)
         val result = controller.onPageLoad()(fakeRequest)
         status(result) mustBe SEE_OTHER
@@ -67,7 +67,7 @@ class AuthActionSpec extends SpecBase {
 
     "the user doesn't have sufficient confidence level" must {
       "redirect the user to the unauthorised page" in {
-        val authAction = new AuthActionImpl(new FakeFailingAuthConnector(new InsufficientConfidenceLevel), frontendAppConfig)
+        val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientConfidenceLevel), frontendAppConfig)
         val controller = new Harness(authAction)
         val result = controller.onPageLoad()(fakeRequest)
         status(result) mustBe SEE_OTHER
@@ -77,7 +77,7 @@ class AuthActionSpec extends SpecBase {
 
     "the user used an unaccepted auth provider" must {
       "redirect the user to the unauthorised page" in {
-        val authAction = new AuthActionImpl(new FakeFailingAuthConnector(new UnsupportedAuthProvider), frontendAppConfig)
+        val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAuthProvider), frontendAppConfig)
         val controller = new Harness(authAction)
         val result = controller.onPageLoad()(fakeRequest)
         status(result) mustBe SEE_OTHER
@@ -87,7 +87,7 @@ class AuthActionSpec extends SpecBase {
 
     "the user has an unsupported affinity group" must {
       "redirect the user to the unauthorised page" in {
-        val authAction = new AuthActionImpl(new FakeFailingAuthConnector(new UnsupportedAffinityGroup), frontendAppConfig)
+        val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAffinityGroup), frontendAppConfig)
         val controller = new Harness(authAction)
         val result = controller.onPageLoad()(fakeRequest)
         status(result) mustBe SEE_OTHER
@@ -97,7 +97,7 @@ class AuthActionSpec extends SpecBase {
 
     "the user has an unsupported credential role" must {
       "redirect the user to the unauthorised page" in {
-        val authAction = new AuthActionImpl(new FakeFailingAuthConnector(new UnsupportedCredentialRole), frontendAppConfig)
+        val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedCredentialRole), frontendAppConfig)
         val controller = new Harness(authAction)
         val result = controller.onPageLoad()(fakeRequest)
         status(result) mustBe SEE_OTHER

--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import base.SpecBase
 import connectors.DataCacheConnector
-import models.requests.{CacheIdentifierRequest, OptionalDataRequest}
+import models.requests.{IdentifierRequest, OptionalDataRequest}
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 import scala.concurrent.Future
@@ -30,7 +30,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class DataRetrievalActionSpec extends SpecBase with MockitoSugar with ScalaFutures {
 
   class Harness(dataCacheConnector: DataCacheConnector) extends DataRetrievalActionImpl(dataCacheConnector) {
-    def callTransform[A](request: CacheIdentifierRequest[A]): Future[OptionalDataRequest[A]] = transform(request)
+    def callTransform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] = transform(request)
   }
 
   "Data Retrieval Action" when {
@@ -40,7 +40,7 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar with ScalaFutur
         when(dataCacheConnector.fetch("id")) thenReturn Future(None)
         val action = new Harness(dataCacheConnector)
 
-        val futureResult = action.callTransform(new CacheIdentifierRequest(fakeRequest, "id"))
+        val futureResult = action.callTransform(new IdentifierRequest(fakeRequest, "id"))
 
         whenReady(futureResult) { result =>
           result.userAnswers.isEmpty mustBe true
@@ -54,7 +54,7 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar with ScalaFutur
         when(dataCacheConnector.fetch("id")) thenReturn Future(Some(new CacheMap("id", Map())))
         val action = new Harness(dataCacheConnector)
 
-        val futureResult = action.callTransform(new CacheIdentifierRequest(fakeRequest, "id"))
+        val futureResult = action.callTransform(new IdentifierRequest(fakeRequest, "id"))
 
         whenReady(futureResult) { result =>
           result.userAnswers.isDefined mustBe true

--- a/test/controllers/actions/FakeCacheIdentifierAction.scala
+++ b/test/controllers/actions/FakeCacheIdentifierAction.scala
@@ -17,12 +17,12 @@
 package controllers.actions
 
 import play.api.mvc.{Request, Result}
-import models.requests.CacheIdentifierRequest
+import models.requests.IdentifierRequest
 
 import scala.concurrent.Future
 
-object FakeCacheIdentifierAction extends CacheIdentifierAction {
-  override def invokeBlock[A](request: Request[A], block: (CacheIdentifierRequest[A]) => Future[Result]): Future[Result] =
-    block(CacheIdentifierRequest(request, "id"))
+object FakeCacheIdentifierAction extends IdentifierAction {
+  override def invokeBlock[A](request: Request[A], block: (IdentifierRequest[A]) => Future[Result]): Future[Result] =
+    block(IdentifierRequest(request, "id"))
 }
 

--- a/test/controllers/actions/FakeDataRetrievalAction.scala
+++ b/test/controllers/actions/FakeDataRetrievalAction.scala
@@ -17,7 +17,7 @@
 package controllers.actions
 
 import uk.gov.hmrc.http.cache.client.CacheMap
-import models.requests.{CacheIdentifierRequest, OptionalDataRequest}
+import models.requests.{IdentifierRequest, OptionalDataRequest}
 import utils.UserAnswers
 
 import scala.concurrent.Future
@@ -25,8 +25,8 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class FakeDataRetrievalAction(cacheMapToReturn: Option[CacheMap]) extends DataRetrievalAction {
-  override protected def transform[A](request: CacheIdentifierRequest[A]): Future[OptionalDataRequest[A]] = cacheMapToReturn match {
-    case None => Future(OptionalDataRequest(request.request, request.cacheId, None))
-    case Some(cacheMap)=> Future(OptionalDataRequest(request.request, request.cacheId, Some(new UserAnswers(cacheMap))))
+  override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] = cacheMapToReturn match {
+    case None => Future(OptionalDataRequest(request.request, request.identifier, None))
+    case Some(cacheMap)=> Future(OptionalDataRequest(request.request, request.identifier, Some(new UserAnswers(cacheMap))))
   }
 }

--- a/test/controllers/actions/SessionActionSpec.scala
+++ b/test/controllers/actions/SessionActionSpec.scala
@@ -25,14 +25,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class SessionActionSpec extends SpecBase {
 
-  class Harness(action: CacheIdentifierAction) extends Controller {
+  class Harness(action: IdentifierAction) extends Controller {
     def onPageLoad() = action { request => Ok }
   }
 
   "Session Action" when {
     "there's no active session" must {
       "redirect to the session expired page" in {
-        val sessionAction = new SessionActionImpl(frontendAppConfig)
+        val sessionAction = new SessionIdentifierAction(frontendAppConfig)
         val controller = new Harness(sessionAction)
         val result = controller.onPageLoad()(fakeRequest)
         status(result) mustBe SEE_OTHER
@@ -41,7 +41,7 @@ class SessionActionSpec extends SpecBase {
     }
     "there's an active session" must {
       "perform the action" in {
-        val sessionAction = new SessionActionImpl(frontendAppConfig)
+        val sessionAction = new SessionIdentifierAction(frontendAppConfig)
         val controller = new Harness(sessionAction)
         val request = fakeRequest.withSession(SessionKeys.sessionId -> "foo")
         val result = controller.onPageLoad()(request)


### PR DESCRIPTION
What do you think about this proposed rename, i.e. : 
- CacheIdentifierAction to IdentifierAction
- CacheIdentifierRequest to IdentifierRequest (and .cacheId to .identifier)
- SessionActionImpl to SessionIdentifierAction
- AuthActionImpl to AuthenticatedIdentifierAction