### PR TITLE
Update service and add styles to adjust header layout

### DIFF
--- a/app/assets/stylesheets/_header-adjust.scss
+++ b/app/assets/stylesheets/_header-adjust.scss
@@ -1,0 +1,28 @@
+/* This is an local CSS adjustment to the header in the GOV UK template */
+
+/*
+	The template header grid split is
+	1/3 for .header-global that contains the GOV.UK logo and crest
+	1/2's for .header-proposition that contains the service name and sign out link if available
+
+	The below code adjusts .header-global to arbitrary 20% with a min-width so that the logo doesn't break and .header-proposition to 80%
+*/
+
+/*
+	If the name changes (shortens) or the template changes (unlikely), then this will need to be either removed or updated, preferrably removed.
+
+	There is potential for this to be included in HMRC Assets Frontend with a modifier class so that it doesn't break any services using the template, but those with longer names can use the modifier class to adjust their header.
+*/
+
+@media (min-width: 769px) {
+	#global-header.with-proposition .header-wrapper .header-global {
+	    width: 20%;
+	    min-width: 185px;
+	}	
+}
+
+@media (min-width: 769px) {
+	#global-header.with-proposition .header-wrapper .header-proposition {
+	    width: 80%;
+	}
+}

--- a/app/assets/stylesheets/companyregistrationeligibilityfrontend-app.scss
+++ b/app/assets/stylesheets/companyregistrationeligibilityfrontend-app.scss
@@ -1,1 +1,2 @@
+@import '_header-adjust';
 @import 'partials/_forms';


### PR DESCRIPTION
This work updates the service name to 'Set up a limited company and register for Corporation Tax'. This however extends the service name further across the page, thus forcing the 'sign in/out' link to drop below, breaking the layout.

I have added some styles which adjust the layout from a 1/3 | 2/3's split to a 20% | 80% split and set the logo with a minimum width so that doesn't break in the lower screen width range of the tablet breakpoint.