### PR TITLE
[SAR-10135] Migrate to HMRC-Mongo from Simple-ReactiveMongo

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -65,6 +65,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
+play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
 play.i18n.langs = ["en"]
 

--- a/it/helpers/FakeConfig.scala
+++ b/it/helpers/FakeConfig.scala
@@ -16,10 +16,10 @@
 
 package helpers
 
-import uk.gov.hmrc.mongo.MongoSpecSupport
+import uk.gov.hmrc.mongo.test.MongoSupport
 
 trait FakeConfig {
-  self: MongoSpecSupport =>
+  self: MongoSupport =>
   val mockHost: String
   val mockPort: Int
   lazy val mockUrl = s"http://$mockHost:$mockPort"

--- a/it/helpers/IntegrationSpecBase.scala
+++ b/it/helpers/IntegrationSpecBase.scala
@@ -22,7 +22,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
-import uk.gov.hmrc.mongo.MongoSpecSupport
+import uk.gov.hmrc.mongo.test.MongoSupport
 
 import scala.concurrent.duration._
 
@@ -36,7 +36,7 @@ trait IntegrationSpecBase
     with BeforeAndAfterAll
     with FutureAwaits
     with DefaultAwaitTimeout
-    with MongoSpecSupport with FakeConfig {
+    with MongoSupport with FakeConfig {
 
   val mockPort = 11111
   val mockHost = "localhost"

--- a/it/helpers/SessionHelper.scala
+++ b/it/helpers/SessionHelper.scala
@@ -16,23 +16,22 @@
 
 package helpers
 
+import org.mongodb.scala.bson.BsonDocument
 import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.{DefaultReads, Format, Json}
 import repositories.ReactiveMongoRepository
 import uk.gov.hmrc.http.cache.client.CacheMap
-import uk.gov.hmrc.mongo.MongoSpecSupport
+import uk.gov.hmrc.mongo.test.MongoSupport
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
-trait SessionHelper extends MongoSpecSupport with BeforeAndAfterEach with DefaultReads {
+trait SessionHelper extends MongoSupport with BeforeAndAfterEach with DefaultReads {
   self: IntegrationSpecBase =>
 
-  lazy val repo = new ReactiveMongoRepository(app.configuration, mongo)
+  lazy val repo = new ReactiveMongoRepository(app.configuration, mongoComponent)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    await(repo.drop)
-    await(repo.count) mustBe 0
+    await(repo.collection.deleteMany(BsonDocument()).toFuture())
+    await(repo.collection.countDocuments().toFuture()) mustBe 0
     resetWiremock()
   }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,28 +4,28 @@ import sbt._
 
 object AppDependencies {
 
+  private val playVersion = "-play-28"
+
   private val logbackJsonLoggerVersion = "5.1.0"
-  private val scalaTestVersion = "3.0.8"
-  private val scalaTestPlusPlayVersion = "4.0.0"
+  private val scalaTestVersion = "3.2.12"
+  private val scalaTestPlusPlayVersion = "5.1.0"
   private val pegdownVersion = "1.6.0"
-  private val mockitoVersion = "3.9.0"
-  private val httpCachingClientVersion = "9.5.0-play-28"
-  private val simpleReactivemongoVersion = "8.0.0-play-28"
-  private val playConditionalFormMappingVersion = "1.9.0-play-28"
-  private val playLanguageVersion = "5.1.0-play-28"
+  private val httpCachingClientVersion = s"9.5.0$playVersion"
+  private val playConditionalFormMappingVersion = s"1.9.0$playVersion"
+  private val playLanguageVersion = s"5.1.0$playVersion"
   private val bootstrapVersion = "5.16.0"
   private val wireMockVersion = "2.27.2"
-  private val reactivemongoTestVersion = "5.0.0-play-28"
-  private val scalacheckVersion = "1.15.3"
-  private val playHmrcFrontendVersion = "1.0.0-play-28"
+  private val playHmrcFrontendVersion = s"1.0.0$playVersion"
+  private val hmrcMongoVersion = "0.71.0"
+  private val flexmarkAllVersion = "0.62.2"
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "simple-reactivemongo" % simpleReactivemongoVersion,
+    "uk.gov.hmrc.mongo" %% s"hmrc-mongo$playVersion" % hmrcMongoVersion,
     "uk.gov.hmrc" %% "logback-json-logger" % logbackJsonLoggerVersion,
     "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion,
     "uk.gov.hmrc" %% "play-conditional-form-mapping" % playConditionalFormMappingVersion,
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapVersion,
+    "uk.gov.hmrc" %% s"bootstrap-frontend$playVersion" % bootstrapVersion,
     "uk.gov.hmrc" %% "play-language" % playLanguageVersion,
     "uk.gov.hmrc" %% "play-frontend-hmrc" % playHmrcFrontendVersion
   )
@@ -36,12 +36,13 @@ object AppDependencies {
     "org.pegdown" % "pegdown" % pegdownVersion % scope,
     "org.jsoup" % "jsoup" % "1.10.3" % scope,
     "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-    "org.scalacheck" %% "scalacheck" % scalacheckVersion % scope
+    "org.scalatestplus" %% "scalacheck-1-16" % s"$scalaTestVersion.0" % scope,
+    "com.vladsch.flexmark" % "flexmark-all" % flexmarkAllVersion % scope
   )
 
   object Test {
     def apply(): Seq[ModuleID] = testDeps("test") ++ Seq(
-      "org.mockito" % "mockito-core" % mockitoVersion % "test"
+      "org.scalatestplus" %% "mockito-4-5" % s"$scalaTestVersion.0" % "test"
     )
 
   }
@@ -49,7 +50,7 @@ object AppDependencies {
   object IntegrationTest {
     def apply(): Seq[ModuleID] = testDeps("it") ++ Seq(
       "com.github.tomakehurst" % "wiremock-jre8" % wireMockVersion % "it",
-      "uk.gov.hmrc" %% "reactivemongo-test" % reactivemongoTestVersion % "it"
+      "uk.gov.hmrc.mongo" %% s"hmrc-mongo-test$playVersion" % hmrcMongoVersion % "it"
     )
   }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,6 @@ object AppDependencies {
   private val logbackJsonLoggerVersion = "5.1.0"
   private val scalaTestVersion = "3.2.12"
   private val scalaTestPlusPlayVersion = "5.1.0"
-  private val pegdownVersion = "1.6.0"
   private val httpCachingClientVersion = s"9.5.0$playVersion"
   private val playConditionalFormMappingVersion = s"1.9.0$playVersion"
   private val playLanguageVersion = s"5.1.0$playVersion"
@@ -33,7 +32,6 @@ object AppDependencies {
   private def testDeps(scope: String) = Seq(
     "org.scalatest" %% "scalatest" % scalaTestVersion % scope,
     "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestPlusPlayVersion % scope,
-    "org.pegdown" % "pegdown" % pegdownVersion % scope,
     "org.jsoup" % "jsoup" % "1.10.3" % scope,
     "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
     "org.scalatestplus" %% "scalacheck-1-16" % s"$scalaTestVersion.0" % scope,

--- a/test/forms/FormSpec.scala
+++ b/test/forms/FormSpec.scala
@@ -16,17 +16,18 @@
 
 package forms
 
-import org.scalatest.{Assertion, Matchers, OptionValues, WordSpec}
+import org.scalatest.{Assertion, OptionValues}
+import org.scalatestplus.play.PlaySpec
 import play.api.data.{Form, FormError}
 
-trait FormSpec extends WordSpec with OptionValues with Matchers {
+trait FormSpec extends PlaySpec with OptionValues {
 
   def checkForError(form: Form[_], data: Map[String, String], expectedErrors: Seq[FormError]): Assertion = {
 
     form.bind(data).fold(
       formWithErrors => {
-        for (error <- expectedErrors) formWithErrors.errors should contain(FormError(error.key, error.message, error.args))
-        formWithErrors.errors.size shouldBe expectedErrors.size
+        for (error <- expectedErrors) formWithErrors.errors must contain(FormError(error.key, error.message, error.args))
+        formWithErrors.errors.size mustBe expectedErrors.size
       },
       _ => {
         fail("Expected a validation error when binding the form, but it was bound successfully.")

--- a/test/forms/behaviours/BooleanFieldBehaviours.scala
+++ b/test/forms/behaviours/BooleanFieldBehaviours.scala
@@ -26,12 +26,12 @@ trait BooleanFieldBehaviours extends FieldBehaviours {
 
     "bind true" in {
       val result = form.bind(Map(fieldName -> "true"))
-      result.value.value shouldBe true
+      result.value.value mustBe true
     }
 
     "bind false" in {
       val result = form.bind(Map(fieldName -> "false"))
-      result.value.value shouldBe false
+      result.value.value mustBe false
     }
 
     "not bind non-booleans" in {
@@ -39,7 +39,7 @@ trait BooleanFieldBehaviours extends FieldBehaviours {
       forAll(nonBooleans -> "nonBoolean") {
         nonBoolean =>
           val result = form.bind(Map(fieldName -> nonBoolean)).apply(fieldName)
-          result.errors shouldEqual Seq(invalidError)
+          result.errors mustEqual Seq(invalidError)
       }
     }
   }

--- a/test/forms/behaviours/FieldBehaviours.scala
+++ b/test/forms/behaviours/FieldBehaviours.scala
@@ -33,7 +33,7 @@ trait FieldBehaviours extends FormSpec with ScalaCheckPropertyChecks with Genera
       forAll(validDataGenerator -> "validDataItem") {
         dataItem: String =>
           val result = form.bind(Map(fieldName -> dataItem)).apply(fieldName)
-          result.value.value shouldBe dataItem
+          result.value.value mustBe dataItem
       }
     }
   }
@@ -45,13 +45,13 @@ trait FieldBehaviours extends FormSpec with ScalaCheckPropertyChecks with Genera
     "not bind when key is not present at all" in {
 
       val result = form.bind(emptyForm).apply(fieldName)
-      result.errors shouldEqual Seq(requiredError)
+      result.errors mustEqual Seq(requiredError)
     }
 
     "not bind blank values" in {
 
       val result = form.bind(Map(fieldName -> "")).apply(fieldName)
-      result.errors shouldEqual Seq(requiredError)
+      result.errors mustEqual Seq(requiredError)
     }
   }
 }

--- a/test/forms/behaviours/FormBehaviours.scala
+++ b/test/forms/behaviours/FormBehaviours.scala
@@ -29,7 +29,7 @@ trait FormBehaviours extends FormSpec {
   def questionForm[A](expectedResult: A): Unit = {
     "bind valid values correctly" in {
       val boundForm = form.bind(validData)
-      boundForm.get shouldBe expectedResult
+      boundForm.get mustBe expectedResult
     }
   }
 
@@ -38,7 +38,7 @@ trait FormBehaviours extends FormSpec {
       s"bind when $field is omitted" in {
         val data = validData - field
         val boundForm = form.bind(data)
-        boundForm.errors.isEmpty shouldBe true
+        boundForm.errors.isEmpty mustBe true
       }
     }
   }
@@ -63,7 +63,7 @@ trait FormBehaviours extends FormSpec {
     s"bind when $booleanField is false and $field is omitted" in {
       val data = validData + (booleanField -> "false") - field
       val boundForm = form.bind(data)
-      boundForm.errors.isEmpty shouldBe true
+      boundForm.errors.isEmpty mustBe true
     }
 
     s"fail to bind when $booleanField is true and $field is omitted" in {
@@ -94,7 +94,7 @@ trait FormBehaviours extends FormSpec {
       s"bind when ${field.name} is set to $validValue" in {
         val data = validData + (field.name -> validValue)
         val boundForm = form.bind(data)
-        boundForm.errors.isEmpty shouldBe true
+        boundForm.errors.isEmpty mustBe true
       }
     }
 

--- a/test/forms/behaviours/IntFieldBehaviours.scala
+++ b/test/forms/behaviours/IntFieldBehaviours.scala
@@ -30,7 +30,7 @@ trait IntFieldBehaviours extends FieldBehaviours {
       forAll(nonNumerics -> "nonNumeric") {
         nonNumeric =>
           val result = form.bind(Map(fieldName -> nonNumeric)).apply(fieldName)
-          result.errors shouldEqual Seq(nonNumericError)
+          result.errors mustEqual Seq(nonNumericError)
       }
     }
 
@@ -39,7 +39,7 @@ trait IntFieldBehaviours extends FieldBehaviours {
       forAll(decimals -> "decimal") {
         decimal =>
           val result = form.bind(Map(fieldName -> decimal)).apply(fieldName)
-          result.errors shouldEqual Seq(wholeNumberError)
+          result.errors mustEqual Seq(wholeNumberError)
       }
     }
 
@@ -48,7 +48,7 @@ trait IntFieldBehaviours extends FieldBehaviours {
       forAll(intsLargerThanMaxValue -> "massiveInt") {
         num: BigInt =>
           val result = form.bind(Map(fieldName -> num.toString)).apply(fieldName)
-          result.errors shouldEqual Seq(nonNumericError)
+          result.errors mustEqual Seq(nonNumericError)
       }
     }
 
@@ -57,7 +57,7 @@ trait IntFieldBehaviours extends FieldBehaviours {
       forAll(intsSmallerThanMinValue -> "massivelySmallInt") {
         num: BigInt =>
           val result = form.bind(Map(fieldName -> num.toString)).apply(fieldName)
-          result.errors shouldEqual Seq(nonNumericError)
+          result.errors mustEqual Seq(nonNumericError)
       }
     }
   }
@@ -72,7 +72,7 @@ trait IntFieldBehaviours extends FieldBehaviours {
       forAll(intsBelowValue(minimum) -> "intBelowMin") {
         number: Int =>
           val result = form.bind(Map(fieldName -> number.toString)).apply(fieldName)
-          result.errors shouldEqual Seq(expectedError)
+          result.errors mustEqual Seq(expectedError)
       }
     }
   }
@@ -87,7 +87,7 @@ trait IntFieldBehaviours extends FieldBehaviours {
       forAll(intsAboveValue(maximum) -> "intAboveMax") {
         number: Int =>
           val result = form.bind(Map(fieldName -> number.toString)).apply(fieldName)
-          result.errors shouldEqual Seq(expectedError)
+          result.errors mustEqual Seq(expectedError)
       }
     }
   }
@@ -103,7 +103,7 @@ trait IntFieldBehaviours extends FieldBehaviours {
       forAll(intsOutsideRange(minimum, maximum) -> "intOutsideRange") {
         number =>
           val result = form.bind(Map(fieldName -> number.toString)).apply(fieldName)
-          result.errors shouldEqual Seq(expectedError)
+          result.errors mustEqual Seq(expectedError)
       }
     }
   }

--- a/test/forms/behaviours/OptionFieldBehaviours.scala
+++ b/test/forms/behaviours/OptionFieldBehaviours.scala
@@ -31,7 +31,7 @@ class OptionFieldBehaviours extends FieldBehaviours {
       for (value <- validValues) {
 
         val result = form.bind(Map(fieldName -> value.toString)).apply(fieldName)
-        result.value.value shouldEqual value.toString
+        result.value.value mustEqual value.toString
       }
     }
 
@@ -43,7 +43,7 @@ class OptionFieldBehaviours extends FieldBehaviours {
         value =>
 
           val result = form.bind(Map(fieldName -> value)).apply(fieldName)
-          result.errors shouldEqual Seq(invalidError)
+          result.errors mustEqual Seq(invalidError)
       }
     }
   }

--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -30,7 +30,7 @@ trait StringFieldBehaviours extends FieldBehaviours {
       forAll(stringsLongerThan(maxLength) -> "longString") {
         string =>
           val result = form.bind(Map(fieldName -> string)).apply(fieldName)
-          result.errors shouldEqual Seq(lengthError)
+          result.errors mustEqual Seq(lengthError)
       }
     }
   }

--- a/test/forms/mappings/ConstraintsSpec.scala
+++ b/test/forms/mappings/ConstraintsSpec.scala
@@ -16,10 +16,10 @@
 
 package forms.mappings
 
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatestplus.play.PlaySpec
 import play.api.data.validation.{Invalid, Valid}
 
-class ConstraintsSpec extends WordSpec with MustMatchers with Constraints {
+class ConstraintsSpec extends PlaySpec with Constraints {
 
 
   "firstError" must {

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -16,7 +16,8 @@
 
 package forms.mappings
 
-import org.scalatest.{MustMatchers, OptionValues, WordSpec}
+import org.scalatest.OptionValues
+import org.scalatestplus.play.PlaySpec
 import play.api.data.{Form, FormError}
 import utils.Enumerable
 
@@ -38,7 +39,7 @@ object MappingsSpec {
 
 }
 
-class MappingsSpec extends WordSpec with MustMatchers with OptionValues with Mappings {
+class MappingsSpec extends PlaySpec with OptionValues with Mappings {
 
   import MappingsSpec._
 

--- a/test/utils/EnumerableSpec.scala
+++ b/test/utils/EnumerableSpec.scala
@@ -16,7 +16,8 @@
 
 package utils
 
-import org.scalatest.{EitherValues, MustMatchers, OptionValues, WordSpec}
+import org.scalatest.{EitherValues, OptionValues}
+import org.scalatestplus.play.PlaySpec
 import play.api.libs.json._
 
 object EnumerableSpec {
@@ -37,7 +38,7 @@ object EnumerableSpec {
 
 }
 
-class EnumerableSpec extends WordSpec with MustMatchers with EitherValues with OptionValues with Enumerable.Implicits {
+class EnumerableSpec extends PlaySpec with EitherValues with OptionValues with Enumerable.Implicits {
 
   import EnumerableSpec._
 

--- a/test/utils/NavigatorSpec.scala
+++ b/test/utils/NavigatorSpec.scala
@@ -37,13 +37,13 @@ class NavigatorSpec extends SpecBase with MockitoSugar {
     }
   }
 
-  "pageIdToPageLoad" should {
+  "pageIdToPageLoad" must {
     "load a page" when {
       Seq(
         SecureRegisterId -> routes.SecureRegisterController.onPageLoad(),
         EligibleId -> routes.EligibleController.onPageLoad()
       ) foreach { case (id, page) =>
-        s"given an ID of ${id.toString} should go to ${page.url}" in {
+        s"given an ID of ${id.toString} must go to ${page.url}" in {
           navigator.pageIdToPageLoad(id).url must include(page.url)
         }
       }
@@ -58,7 +58,7 @@ class NavigatorSpec extends SpecBase with MockitoSugar {
     }
   }
 
-  "nextOnFalse" should {
+  "nextOnFalse" must {
     "return an ID and function to the next page" when {
       "given a start page id and end page id when the answer provided is false" in {
         val res = navigator.nextOn(PaymentOptionId, SecureRegisterId)

--- a/test/utils/WithNameSpec.scala
+++ b/test/utils/WithNameSpec.scala
@@ -16,9 +16,9 @@
 
 package utils
 
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatestplus.play.PlaySpec
 
-class WithNameSpec extends WordSpec with MustMatchers {
+class WithNameSpec extends PlaySpec {
 
   object Foo extends WithName("bar")
 


### PR DESCRIPTION
**Note:** had to update some ScalaTest dependencies at the same time due to transitive conflicts and evictions
- App-Config-QA: https://github.com/hmrc/app-config-qa/pull/16001
- App-Config-Staging: https://github.com/hmrc/app-config-staging/pull/11088
- App-Config-Production: https://github.com/hmrc/app-config-production/pull/15719